### PR TITLE
Refactor to enable a library interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --workspace
+          args: --all-targets --all-features -- -D warnings
 
   cargo_deny:
     name: pipeline_cargo_deny

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [stable, beta, nightly, macos, win-gnu, win-msvc]
+        build: [win-gnu, win-msvc]
         include:
           # latest rust stable :: ubuntu
           - build: stable
@@ -72,7 +72,6 @@ jobs:
 
       - name: test_workspace_crates_except_macos
         uses: actions-rs/cargo@v1
-        if: ${{ matrix.build }} != macos
         with:
           command: test
           args: --verbose --all -- --test-threads=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,17 +70,13 @@ jobs:
           command: build
           args: --verbose --all
 
-      - name: test_workspace_crates
+      - name: test_workspace_crates_except_macos
         uses: actions-rs/cargo@v1
+        if: ${{ matrix.build }} != macos
         with:
           command: test
           args: --verbose --all
 
-      - name: test_workspace_with_all_features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --all --all-features
 
   rustfmt:
     name: pipeline_rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        build: [win-gnu, win-msvc]
+        build: [stable, beta, nightly, macos, win-gnu, win-msvc]
         include:
           # latest rust stable :: ubuntu
           - build: stable
@@ -69,13 +69,6 @@ jobs:
         with:
           command: build
           args: --verbose --all
-
-      - name: test_workspace_crates_except_macos
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --all -- --test-threads=1
-
 
   rustfmt:
     name: pipeline_rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         if: ${{ matrix.build }} != macos
         with:
           command: test
-          args: --verbose --all
+          args: --verbose --all -- --test-threads=1
 
 
   rustfmt:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "doc-comment 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,12 +259,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "dlib"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libloading 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "downcast-rs"
@@ -557,8 +579,10 @@ name = "miniview"
 version = "0.3.0"
 dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+ "assert_cmd 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.21.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parameterized 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "piston_window 0.89.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -666,6 +690,24 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parameterized"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "parameterized-macro 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "parameterized-macro"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.30 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -835,6 +877,29 @@ dependencies = [
  "deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-iter 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "predicates"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1196,6 +1261,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "treeline"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +1297,14 @@ dependencies = [
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "walkdir"
@@ -1378,6 +1456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
 "checksum approx 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
+"checksum assert_cmd 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c88b9ca26f9c16ec830350d309397e74ee9abdfd8eb1f71cb6ecc71a3fc818da"
 "checksum atty 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
@@ -1401,7 +1480,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4"
 "checksum derivative 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3c6d883546668a3e2011b6a716a7330b82eabb0151b138217f632c8243e17135"
+"checksum difference 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 "checksum dlib 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b11f15d1e3268f140f68d390637d5e76d849782d971ae7063e0da69fe9709a76"
+"checksum doc-comment 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 "checksum downcast-rs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52ba6eb47c2131e784a38b726eb54c1e1484904f013e576a25354d0124161af6"
 "checksum draw_state 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "33cf9537e2d06891448799b96d5a8c8083e0e90522a7fdabe6ebf4f41d79d651"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
@@ -1451,6 +1532,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "18869315e81473c951eb56ad5558bbc56978562d3ecfb87abb7a1e944cea4518"
 "checksum osmesa-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "88cfece6e95d2e717e0872a7f53a8684712ad13822a7979bc760b9c77ec0013b"
 "checksum owning_ref 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
+"checksum parameterized 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c90f4967be855698ec6ad2f3711c3bac48044f3f92d236157938502603df75f3"
+"checksum parameterized-macro 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8a01df7a2035840851c9bc9bcf132255a150b7914883e8d6958b3d628b7dd15b"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
@@ -1469,6 +1552,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pistoncore-window 0.37.0 (registry+https://github.com/rust-lang/crates.io-index)" = "863934d0663db43e6737ac8bf947e09fc2d4d06ab95b46a75b999e8bc34b1ddd"
 "checksum pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "05da548ad6865900e60eaba7f589cc0783590a92e940c26953ff81ddbab2d677"
 "checksum png 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "63daf481fdd0defa2d1d2be15c674fbfa1b0fd71882c303a91f9a79b3252c359"
+"checksum predicates 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "347a1b6f0b21e636bc9872fb60b83b8e185f6f5516298b8238699f7f9a531030"
+"checksum predicates-core 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "06075c3a3e92559ff8929e7a280684489ea27fe44805174c3ebd9328dcb37178"
+"checksum predicates-tree 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8e63c4859013b38a76eca2414c64911fba30def9e3202ac461a2d22831220124"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
@@ -1512,12 +1598,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thiserror 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
 "checksum thiserror-impl 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
 "checksum tiff 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1e4834f28a0330cb9f3f2c87d2649dca723cb33802e2bdcf18da32759fbec7ce"
+"checksum treeline 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f741b240f1a48843f9b8e0444fb55fb2a4ff67293b50a9179dfd5ea67f8d41"
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 "checksum vecmath 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1bdd6034ee9c1e5e12485f3e4120e12777f6c81cf43bf9a73bff98ed2b479afe"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+"checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 "checksum walkdir 2.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 "checksum wayland-client 0.21.13 (registry+https://github.com/rust-lang/crates.io-index)" = "49963e5f9eeaf637bfcd1b9f0701c99fd5cd05225eb51035550d4272806f2713"
 "checksum wayland-commons 0.21.13 (registry+https://github.com/rust-lang/crates.io-index)" = "40c08896768b667e1df195d88a62a53a2d1351a1ed96188be79c196b35bb32ec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -576,7 +576,7 @@ dependencies = [
 
 [[package]]
 name = "miniview"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_cmd 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "miniview"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Martijn Gribnau <garm@ilumeo.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ piston_window = "0.89.0"
 
 anyhow = "1.0.31"
 thiserror = "1.0.19"
+
+[dev-dependencies]
+assert_cmd = "1.0.1"
+parameterized = "0.1.1"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [<img alt="github" src="https://img.shields.io/badge/github-foresterre/miniview-blue?labelColor=555555&logo=github" height="20">](https://github.com/foresterre/miniview)
 [<img alt="crates.io" src="https://img.shields.io/crates/v/miniview.svg?color=fc8d62&logo=rust" height="20">](https://crates.io/crates/miniview)
-[<img alt="ci" src="https://img.shields.io/github/workflow/status/foresterre/miniview/github_actions_ci/master" height="20">](https://github.com/foresterre/miniview/actions?query=workflow%3Agithub_actions_ci+branch%3Amaster+)
+[<img alt="ci" src="https://img.shields.io/github/workflow/status/foresterre/miniviehttps://img.shields.io/badge/api-rustdoc-blue.svgw/github_actions_ci/master" height="20">](https://github.com/foresterre/miniview/actions?query=workflow%3Agithub_actions_ci+branch%3Amaster+)
+[<img alt="docs-rs" src="https://docs.rs/miniview/badge.svg" height="20">](https://docs.rs/miniview)
 
 # miniview
 _'mini' as in, it can't do much =)_

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ With [cargo](https://crates.io/crates/miniview) install: `cargo install --force 
 Pre build binary: see [releases](https://github.com/foresterre/miniview/releases)
 
 
-# Usage
+# Usage (binary)
 
 | Usage | Linux example | Windows example (cmd.exe) |
 |----------------------------------------|------------------------------------------------|------------------------------------------------|
@@ -32,12 +32,38 @@ Pre build binary: see [releases](https://github.com/foresterre/miniview/releases
 | ---    | ---         |
 | `--fullscreen` | Set the window to fullscreen |
 | `--allow-window-resizing` | Allow the window to resize (doesn't resize the image!) |
+| `--close-after <n>` | Close the window after `n` milliseconds |
 
 <br>
 
 **Keyboard shortcuts**
 
 Press `ESC` to exit the image window.
+
+# Usage example (library)
+
+```rust
+use miniview::config::ConfigBuilder;
+use std::time::Duration;
+
+fn main() {
+    let start = std::time::Instant::now();
+
+    let timer = Box::new(move || {
+        let time_passed = std::time::Instant::now().duration_since(start);
+        time_passed >= Duration::new(1, 0)
+    });
+
+    let config =
+        ConfigBuilder::from_path(concat!(env!("CARGO_MANIFEST_DIR"), "/resources/plant.jpg"))
+            .set_fullscreen(true)
+            .set_lazy_window(false)
+            .close_window_when(Some(timer))
+            .build();
+
+    miniview::show(&config).unwrap()
+}
+```
 
 # Suggestions, Questions, Bugs
 

--- a/README.md
+++ b/README.md
@@ -48,21 +48,19 @@ use miniview::config::ConfigBuilder;
 use std::time::Duration;
 
 fn main() {
-    let start = std::time::Instant::now();
-
-    let timer = Box::new(move || {
-        let time_passed = std::time::Instant::now().duration_since(start);
-        time_passed >= Duration::new(1, 0)
-    });
-
     let config =
         ConfigBuilder::from_path(concat!(env!("CARGO_MANIFEST_DIR"), "/resources/plant.jpg"))
             .set_fullscreen(true)
             .set_lazy_window(false)
-            .close_window_when(Some(timer))
             .build();
 
-    miniview::show(&config).unwrap()
+    let controls = MiniView::show(config).expect("unable to create miniview");
+
+    // do some important other work!
+    std::thread::sleep(Duration::from_millis(1000));
+
+    let closed = controls.close();
+    assert!(closed.is_ok());
 }
 ```
 

--- a/examples/exit_after_1_second.rs
+++ b/examples/exit_after_1_second.rs
@@ -1,20 +1,18 @@
-use miniview::config::ConfigBuilder;
+use miniview::{ConfigBuilder, MiniView};
 use std::time::Duration;
 
 fn main() {
-    let start = std::time::Instant::now();
-
-    let timer = Box::new(move || {
-        let time_passed = std::time::Instant::now().duration_since(start);
-        time_passed >= Duration::new(1, 0)
-    });
-
     let config =
         ConfigBuilder::from_path(concat!(env!("CARGO_MANIFEST_DIR"), "/resources/plant.jpg"))
             .set_fullscreen(true)
             .set_lazy_window(false)
-            .close_window_when(Some(timer))
             .build();
 
-    miniview::show(&config).unwrap()
+    let controls = MiniView::show(config).expect("unable to create miniview");
+
+    // do some important other work!
+    std::thread::sleep(Duration::from_millis(1000));
+
+    let closed = controls.close();
+    assert!(closed.is_ok());
 }

--- a/examples/exit_after_1_second.rs
+++ b/examples/exit_after_1_second.rs
@@ -1,0 +1,20 @@
+use miniview::config::ConfigBuilder;
+use std::time::Duration;
+
+fn main() {
+    let start = std::time::Instant::now();
+
+    let timer = Box::new(move || {
+        let time_passed = std::time::Instant::now().duration_since(start);
+        time_passed >= Duration::new(1, 0)
+    });
+
+    let config =
+        ConfigBuilder::from_path(concat!(env!("CARGO_MANIFEST_DIR"), "/resources/plant.jpg"))
+            .set_fullscreen(true)
+            .set_lazy_window(false)
+            .close_window_when(Some(timer))
+            .build();
+
+    miniview::show(&config).unwrap()
+}

--- a/examples/update_dep_licenses.rs
+++ b/examples/update_dep_licenses.rs
@@ -1,3 +1,5 @@
+// NOTE: This is not actually an example!
+//
 // Copyright © 2018 Martijn Gribnau
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,18 @@
+//! In order to display the miniview window, a configuration which defines how the view should be
+//! presented is required. This [`configuration`] may be constructed manually, or by using the
+//! [`ConfigBuilder`] which leverages the builder pattern.
+//!
+//! [`configuration`]: struct.Config.html
+//! [`ConfigBuilder`]: struct.ConfigBuilder.html
+//! [`show`]: ../struct.MiniView.html#method.show
+
 use crate::Source;
 use std::fmt::{Debug, Formatter};
 
+/// Configuration which can be [`provided`] to a miniview window controlling instance which enables
+/// different program behaviours
+///
+/// [`provided`]: ../struct.MiniView.html#method.show
 pub struct Config {
     source: Source,
     fullscreen: bool,
@@ -10,18 +22,29 @@ pub struct Config {
 }
 
 impl Config {
+    /// Source of the image
     pub fn source(&self) -> &Source {
         &self.source
     }
 
+    /// Whether the window should open in fullscreen mode or not
     pub fn fullscreen(&self) -> bool {
         self.fullscreen
     }
 
+    /// Whether the window should be resizable or not
+    ///
+    /// If [`fullscreen`] mode is active for the window, this setting is implied.
+    ///
+    /// [`fullscreen`]: struct.Config.html#method.fullscreen
     pub fn resizable_window(&self) -> bool {
         self.resizable_window
     }
 
+    /// Whether the window continuously or lazily checks for input events
+    ///
+    /// Note: if this is set to true, the [`MiniView.close`] method will only close upon receiving
+    /// some input event.
     pub fn lazy_window(&self) -> bool {
         self.lazy_window
     }
@@ -38,12 +61,18 @@ impl<'window_name> Debug for Config {
     }
 }
 
+/// Builder to conveniently create a miniview [`configuration`]
+///
+/// [`configuration`]: struct.Config.html
 #[derive(Debug)]
 pub struct ConfigBuilder {
     config: Config,
 }
 
 impl ConfigBuilder {
+    /// Create a builder from the provided [`source`]
+    ///
+    /// [`source`]: ../enum.Source.html
     pub fn new(source: Source) -> Self {
         ConfigBuilder {
             config: Config {
@@ -56,17 +85,21 @@ impl ConfigBuilder {
         }
     }
 
+    /// Creates a builder from the provided path
+    ///
+    /// Path should point to an image on the filesystem.
     pub fn from_path<P: AsRef<std::path::Path>>(path: P) -> Self {
         Self::new(Source::ByPath(path.as_ref().to_path_buf()))
     }
 
-    /// Where to load the image from
+    /// Source of the image to be shown by the window. Can be a path or raw bytes imported from the
+    /// stdin pipe
     pub fn source(mut self, value: Source) -> Self {
         self.config.source = value;
         self
     }
 
-    /// Activates fullscreen
+    /// Activates fullscreen mode
     pub fn set_fullscreen(mut self, value: bool) -> Self {
         self.config.fullscreen = value;
         self
@@ -83,7 +116,7 @@ impl ConfigBuilder {
 
     /// Lazily update the window
     ///
-    /// Warning: if the window uses lazy updates, events may not work as expected (user interaction
+    /// Warning: if the window uses lazy updates, events may not work as expected (input events are
     /// is required to poll successive window events in lazy window mode).
     pub fn set_lazy_window(mut self, value: bool) -> Self {
         self.config.lazy_window = value;
@@ -96,6 +129,7 @@ impl ConfigBuilder {
         self
     }
 
+    /// Construct a configuration from the default and overridden configuration values.
     pub fn build(self) -> Config {
         self.config
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,6 @@ pub struct Config {
     fullscreen: bool,
     resizable_window: bool,
     lazy_window: bool,
-    exit_when: Option<Box<dyn Fn() -> bool>>,
     window_name: &'static str,
 }
 
@@ -30,13 +29,9 @@ impl Config {
     pub fn window_name(&self) -> &str {
         self.window_name
     }
-
-    pub fn exit_when(&self) -> Option<&dyn Fn() -> bool> {
-        self.exit_when.as_ref().map(|inner| inner.as_ref())
-    }
 }
 
-impl<'a> Debug for Config {
+impl<'window_name> Debug for Config {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str(&format!("Config(source = {:?}, fullscreen = {:?}, resizable_window = {:?}, window_name = {:?}, ...)",
                              self.source, self.fullscreen, self.resizable_window, self.window_name))
@@ -48,16 +43,15 @@ pub struct ConfigBuilder {
     config: Config,
 }
 
-impl<'a> ConfigBuilder {
+impl ConfigBuilder {
     pub fn new(source: Source) -> Self {
         ConfigBuilder {
             config: Config {
                 source,
                 fullscreen: false,
                 resizable_window: false,
-                lazy_window: true,
+                lazy_window: false,
                 window_name: "miniview",
-                exit_when: None,
             },
         }
     }
@@ -99,15 +93,6 @@ impl<'a> ConfigBuilder {
     /// Title of the window; useful when trying to capture the window from another program.
     pub fn window_name(mut self, value: &'static str) -> Self {
         self.config.window_name = value;
-        self
-    }
-
-    /// Close the window in certain cases.
-    ///
-    /// Warning: if the window uses lazy updates, this may not work as intended (as user interaction
-    /// is required to poll successive window events).
-    pub fn close_window_when(mut self, value: Option<Box<dyn Fn() -> bool>>) -> Self {
-        self.config.exit_when = value;
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,117 @@
+use crate::Source;
+use std::fmt::{Debug, Formatter};
+
+pub struct Config {
+    source: Source,
+    fullscreen: bool,
+    resizable_window: bool,
+    lazy_window: bool,
+    exit_when: Option<Box<dyn Fn() -> bool>>,
+    window_name: &'static str,
+}
+
+impl Config {
+    pub fn source(&self) -> &Source {
+        &self.source
+    }
+
+    pub fn fullscreen(&self) -> bool {
+        self.fullscreen
+    }
+
+    pub fn resizable_window(&self) -> bool {
+        self.resizable_window
+    }
+
+    pub fn lazy_window(&self) -> bool {
+        self.lazy_window
+    }
+
+    pub fn window_name(&self) -> &str {
+        self.window_name
+    }
+
+    pub fn exit_when(&self) -> Option<&dyn Fn() -> bool> {
+        self.exit_when.as_ref().map(|inner| inner.as_ref())
+    }
+}
+
+impl<'a> Debug for Config {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&format!("Config(source = {:?}, fullscreen = {:?}, resizable_window = {:?}, window_name = {:?}, ...)",
+                             self.source, self.fullscreen, self.resizable_window, self.window_name))
+    }
+}
+
+#[derive(Debug)]
+pub struct ConfigBuilder {
+    config: Config,
+}
+
+impl<'a> ConfigBuilder {
+    pub fn new(source: Source) -> Self {
+        ConfigBuilder {
+            config: Config {
+                source,
+                fullscreen: false,
+                resizable_window: false,
+                lazy_window: true,
+                window_name: "miniview",
+                exit_when: None,
+            },
+        }
+    }
+
+    pub fn from_path<P: AsRef<std::path::Path>>(path: P) -> Self {
+        Self::new(Source::ByPath(path.as_ref().to_path_buf()))
+    }
+
+    /// Where to load the image from
+    pub fn source(mut self, value: Source) -> Self {
+        self.config.source = value;
+        self
+    }
+
+    /// Activates fullscreen
+    pub fn set_fullscreen(mut self, value: bool) -> Self {
+        self.config.fullscreen = value;
+        self
+    }
+
+    /// Allow window resizing
+    ///
+    /// Note: Upon resizing of the window, the image itself is not resized
+    /// Note: Fullscreen mode implies window resizing
+    pub fn allow_resizable_window(mut self, value: bool) -> Self {
+        self.config.resizable_window = value;
+        self
+    }
+
+    /// Lazily update the window
+    ///
+    /// Warning: if the window uses lazy updates, events may not work as expected (user interaction
+    /// is required to poll successive window events in lazy window mode).
+    pub fn set_lazy_window(mut self, value: bool) -> Self {
+        self.config.lazy_window = value;
+        self
+    }
+
+    /// Title of the window; useful when trying to capture the window from another program.
+    pub fn window_name(mut self, value: &'static str) -> Self {
+        self.config.window_name = value;
+        self
+    }
+
+    /// Close the window in certain cases.
+    ///
+    /// Warning: if the window uses lazy updates, this may not work as intended (as user interaction
+    /// is required to poll successive window events).
+    pub fn close_window_when(mut self, value: Option<Box<dyn Fn() -> bool>>) -> Self {
+        self.config.exit_when = value;
+        self
+    }
+
+    pub fn build(self) -> Config {
+        self.config
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,11 +11,17 @@ pub enum MiniViewError {
     #[error("Unable to determine input mode.")]
     CliUnableToDetermineInputMode,
 
+    #[error("Unable to signal window to stop showing")]
+    SendStopError,
+
     #[error("Unable to create a window to display the image.")]
     UnableToCreateWindow,
 
     #[error("Unable to map the image to a texture.")]
     UnableToMapImage,
+
+    #[error("View thread exited improperly")]
+    ViewThreadFailedToJoin,
 }
 
 #[derive(Error, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,43 +1,68 @@
+//! Errors which signal faulty behaviour.
+//!
+//! MiniView attempts to always return an error in case of faulty behaviour instead of crashing
+//! by virtue of panicking.
+
 use thiserror::Error;
 
+/// The top-level error type
 #[derive(Error, Debug)]
 pub enum MiniViewError {
+    /// Returned in case an empty input path is given
     #[error("No path to an image was provided.")]
     EmptyInputPath,
 
+    /// Returned in case an image can not be loaded from a [`source`].
+    ///
+    /// [`source`]: ../enum.Source.html
     #[error(transparent)]
     FailedToImport(#[from] ImportError),
 
+    /// Returned if the input mode could not be defined
     #[error("Unable to determine input mode.")]
     CliUnableToDetermineInputMode,
 
+    /// Returned if inter-thread communication trough a multi-producer single-consumer channel
+    /// failed
     #[error("Unable to signal window to stop showing")]
     SendStopError,
 
+    /// Created when it was not possible to create a graphical window
     #[error("Unable to create a window to display the image.")]
     UnableToCreateWindow,
 
+    /// Returned if an image could not be mapped to the texture which is shown by the image view
+    /// in the window
     #[error("Unable to map the image to a texture.")]
     UnableToMapImage,
 
+    /// Returned when a thread does not exit properly
     #[error("View thread exited improperly")]
     ViewThreadFailedToJoin,
 }
 
+/// Errors related to loading an image from a path or stream
 #[derive(Error, Debug)]
 pub enum ImportError {
+    /// Returned when a path can't be found on the filesystem
     #[error("Provided path to image could not be found or loaded.")]
     OnPathNotFound,
 
+    /// Returned when the program is unable to read from the stdin
     #[error("Unable to read from the stdin.")]
     OnStdinUnableToRead,
 
+    /// Returned when the program expects a qualified path from the stdin, but the given path is empty  
     #[error("Given path to image was empty.")]
     OnStdinPathWasEmpty,
 
+    /// Returned when the program expects an ordered stream of bytes (the formatted image) from the
+    /// stdin, but the stdin did not receive any input
     #[error("Stdin was empty.")]
     OnStdinBytesStreamWasEmpty,
 
+    /// Returned when the program expects an ordered stream of bytes (the formatted image) from the
+    /// stdin, but the given bytes could not be decoded
     #[error("The input received from stdin could not be loaded.")]
     OnStdinBytesUnableToGuessOrLoadFormat,
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -2,7 +2,7 @@ use std::io::{stdin, Read};
 
 use crate::errors::{ImportError, MiniViewError};
 
-pub(crate) fn import_image_from_stdin_bytes_block() -> Result<image::DynamicImage, MiniViewError> {
+pub fn import_image_from_stdin_bytes_block() -> Result<image::DynamicImage, MiniViewError> {
     let mut buffer = Vec::new();
 
     stdin()
@@ -21,7 +21,7 @@ pub(crate) fn import_image_from_stdin_bytes_block() -> Result<image::DynamicImag
     })
 }
 
-pub(crate) fn read_path_from_stdin_block() -> Result<String, MiniViewError> {
+pub fn read_path_from_stdin_block() -> Result<String, MiniViewError> {
     let mut path = String::new();
 
     stdin()

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,7 +1,11 @@
+//! Convenience functions to load a bytestream representing a path to an image or the image itself
+//! from the stdin pipe.
+
 use std::io::{stdin, Read};
 
 use crate::errors::{ImportError, MiniViewError};
 
+/// Load an image from stdin (blocks the thread)
 pub fn import_image_from_stdin_bytes_block() -> Result<image::DynamicImage, MiniViewError> {
     let mut buffer = Vec::new();
 
@@ -21,6 +25,7 @@ pub fn import_image_from_stdin_bytes_block() -> Result<image::DynamicImage, Mini
     })
 }
 
+// Read a path which should point to an image file from stdin (blocks the thread)
 pub fn read_path_from_stdin_block() -> Result<String, MiniViewError> {
     let mut path = String::new();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,20 +20,17 @@
 //! use miniview::{ConfigBuilder, MiniView};
 //! use std::time::Duration;
 //!
-//! fn main() {
-//!     let config =
-//!         ConfigBuilder::from_path(concat!(env!("CARGO_MANIFEST_DIR"), "/resources/plant.jpg"))
-//!             .set_fullscreen(true)
-//!             .build();
+//! let config = ConfigBuilder::from_path(concat!(env!("CARGO_MANIFEST_DIR"), "/resources/plant.jpg"))
+//!         .set_fullscreen(true)
+//!         .build();
 //!
-//!     let controls = MiniView::show(config).expect("unable to create miniview");
+//! let controls = MiniView::show(config).expect("unable to create miniview");
 //!
-//!     // do some important other work!
-//!     std::thread::sleep(Duration::from_millis(1000));
+//! // do some important other work!
+//! std::thread::sleep(Duration::from_millis(1000));
 //!
-//!     let closed = controls.close();
-//!     assert!(closed.is_ok());
-//! }
+//! let closed = controls.close();
+//! assert!(closed.is_ok());
 //! ```
 //!
 //! [`issue tracker`]: https://github.com/foresterre/miniview/issues

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,81 @@
+extern crate image as imagecrate; // There is also an image module in piston_window
+
+use crate::config::Config;
+use crate::errors::{ImportError, MiniViewError};
+use crate::io::import_image_from_stdin_bytes_block;
+use clap::crate_name;
+use imagecrate::{DynamicImage, GenericImageView};
+use piston_window::*;
+use std::path::PathBuf;
+
+pub mod config;
+pub mod errors;
+pub mod io;
+
+trait ResizableWhen {
+    fn resizable_when<P: Fn() -> bool>(self, predicate: P) -> Self;
+}
+
+impl ResizableWhen for WindowSettings {
+    fn resizable_when<P: Fn() -> bool>(self, predicate: P) -> Self {
+        if predicate() {
+            self.resizable(true)
+        } else {
+            self.resizable(false)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Source {
+    ByPath(PathBuf),
+    StdinBytes,
+}
+
+impl Source {
+    fn open(&self) -> Result<DynamicImage, MiniViewError> {
+        match &self {
+            Source::ByPath(path) => imagecrate::open(path.as_path())
+                .map_err(|_| MiniViewError::FailedToImport(ImportError::OnPathNotFound)),
+            Source::StdinBytes => import_image_from_stdin_bytes_block(),
+        }
+    }
+}
+
+pub fn show(config: &Config) -> Result<(), MiniViewError> {
+    let source = config.source();
+    let img = source.open()?;
+
+    let width = img.width();
+    let height = img.height();
+    let img = img.to_rgba();
+
+    let mut window: PistonWindow = WindowSettings::new(crate_name!(), [width, height])
+        .fullscreen(config.fullscreen())
+        .exit_on_esc(true)
+        .resizable_when(|| {
+            // if window resizing is not enabled, when setting fullscreen to true, the window won't go
+            // into fullscreen mode
+            config.fullscreen() || config.resizable_window()
+        })
+        .build()
+        .map_err(|_| MiniViewError::UnableToCreateWindow)?;
+
+    let tex = Texture::from_image(&mut window.factory, &img, &TextureSettings::new())
+        .map_err(|_| MiniViewError::UnableToMapImage)?;
+
+    window.set_lazy(config.lazy_window());
+    while let Some(event) = window.next() {
+        if let Some(should_exit) = config.exit_when() {
+            if should_exit() {
+                window.set_should_close(true);
+            }
+        }
+
+        window.draw_2d(&event, |c, g| {
+            image(&tex, c.transform, g);
+        });
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,46 @@
+//! MiniView is a small program which allows to show a single image in a graphical window.
+//! It supports both windowed mode and fullscreen mode and can be useful for debugging or testing
+//! programs dealing with images.
+//!
+//! MiniView can be used both as a binary executable (usually `miniview` or `miniview.exe`),
+//! or as a library.
+//!
+//! If you want to use a `miniview` binary, provide the `--help` flag for information on its usage
+//! and options. In addition, you could take a look at the [`readme`].
+//!
+//! For library usage you may want to start by looking at the [`MiniView.show`] method and
+//! [`ConfigBuilder`] struct, to respectively create a `MiniView` window controlling instance and
+//! conveniently create a configuration which is required for `MiniView.show`.
+//!
+//! Feel free to post questions, issues, suggestions and feedback at the [`issue tracker`].
+//!
+//! Example usage:
+//!
+//! ```rust
+//! use miniview::{ConfigBuilder, MiniView};
+//! use std::time::Duration;
+//!
+//! fn main() {
+//!     let config =
+//!         ConfigBuilder::from_path(concat!(env!("CARGO_MANIFEST_DIR"), "/resources/plant.jpg"))
+//!             .set_fullscreen(true)
+//!             .build();
+//!
+//!     let controls = MiniView::show(config).expect("unable to create miniview");
+//!
+//!     // do some important other work!
+//!     std::thread::sleep(Duration::from_millis(1000));
+//!
+//!     let closed = controls.close();
+//!     assert!(closed.is_ok());
+//! }
+//! ```
+//!
+//! [`issue tracker`]: https://github.com/foresterre/miniview/issues
+//! [`readme`]: https://github.com/foresterre/miniview/blob/master/README.md
+//! [`MiniView.show`]: struct.MiniView.html#method.show
+//! [`ConfigBuilder`]: config/struct.ConfigBuilder.html
+
 extern crate image as imagecrate; // There is also an image module in piston_window
 
 use crate::config::Config;
@@ -18,6 +61,11 @@ pub mod config;
 pub mod errors;
 pub mod io;
 
+/// A convenience type alias which represents a regular [`Result`] where the error type is
+/// represented by the [`MiniViewError`], which is the top-level error type for this crate.
+///
+/// [`Result`]: https://doc.rust-lang.org/stable/core/result/enum.Result.html
+/// [`MiniViewError`]: errors/enum.MiniViewError.html
 pub type MVResult<T> = Result<T, MiniViewError>;
 
 trait ResizableWhen {
@@ -34,13 +82,20 @@ impl ResizableWhen for WindowSettings {
     }
 }
 
+/// The source of an image which will be shown by the view
 #[derive(Debug, Clone)]
 pub enum Source {
+    /// A path which points at an image file, e.g. `/home/myuser/image.png` or
+    /// `C:/Users/MyUser/image.png`.
     ByPath(PathBuf),
+
+    /// A raw (as in an image formatted using a supported encoding as byte stream) image piped or
+    /// otherwise provided to the stdin
     StdinBytes,
 }
 
 impl Source {
+    /// Load the image to memory
     fn open(&self) -> MVResult<DynamicImage> {
         match &self {
             Source::ByPath(path) => imagecrate::open(path.as_path())
@@ -102,12 +157,31 @@ impl Debug for ImageWindow {
     }
 }
 
+/// Provides the controls to show and consecutively close a `miniview` window
+///
+/// For more, see [`show`].
+///
+/// [`show`]: struct.MiniView.html#method.show
 pub struct MiniView {
     sender: mpsc::Sender<Action>,
     handle: thread::JoinHandle<Result<(), MiniViewError>>,
 }
 
 impl MiniView {
+    /// Create the controls to a new `miniview` window
+    ///
+    /// This will spawn a thread which will manage and create a graphical window. The
+    /// [`MiniView`] struct on the main thread can be used to control the window.
+    ///
+    /// The window can be closed explicitly by calling [`close`] or we can wait until the user will
+    /// close the window manually by using [`wait_for_exit`] instead.
+    ///
+    /// When a [`MiniView`] instance goes out of scope and is dropped, the thread managing the
+    /// graphical image view window will also die.
+    ///
+    /// [`MiniView`]: struct.MiniView.html
+    /// [`close`]: struct.MiniView.html#method.close
+    /// [`wait_for_exit`]: struct.MiniView.html#method.wait_for_exit
     pub fn show(config: Config) -> MVResult<Self> {
         let (sender, receiver) = mpsc::channel();
 
@@ -158,6 +232,14 @@ impl MiniView {
         Ok(Self { sender, handle })
     }
 
+    /// Sends a 'close window' event to the thread managing the graphical window and waits for the
+    /// thread to return
+    ///
+    /// Compared to [`wait_for_exit`] this method will explicitly attempt to close the window,
+    /// and should close almost instantly. This method blocks the until the window has been closed,
+    /// and the thread has been returned, _or_ an error has been returned instead.
+    ///
+    /// [`wait_for_exit`]: struct.MiniView.html#method.wait_for_exit
     pub fn close(self) -> MVResult<()> {
         self.sender
             .send(Action::Close)
@@ -169,6 +251,12 @@ impl MiniView {
             .and_then(|inner| inner)
     }
 
+    /// Waits until the thread managing the graphical window returns
+    ///
+    /// Compared to [`close`] which attempts to instantaneously close the window regardless of user
+    /// input, this method will block and wait for the user to close the window.
+    ///
+    /// [`close`]: struct.MiniView.html#method.close
     pub fn wait_for_exit(self) -> MVResult<()> {
         self.handle
             .join()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,16 +1,24 @@
 extern crate image as imagecrate; // There is also an image module in piston_window
 
 use crate::config::Config;
-use crate::errors::{ImportError, MiniViewError};
+use crate::errors::ImportError;
 use crate::io::import_image_from_stdin_bytes_block;
 use clap::crate_name;
 use imagecrate::{DynamicImage, GenericImageView};
 use piston_window::*;
+use std::fmt::{Debug, Formatter};
 use std::path::PathBuf;
+use std::sync::mpsc;
+use std::thread;
+
+pub use crate::config::ConfigBuilder;
+pub use crate::errors::MiniViewError;
 
 pub mod config;
 pub mod errors;
 pub mod io;
+
+pub type MVResult<T> = Result<T, MiniViewError>;
 
 trait ResizableWhen {
     fn resizable_when<P: Fn() -> bool>(self, predicate: P) -> Self;
@@ -33,7 +41,7 @@ pub enum Source {
 }
 
 impl Source {
-    fn open(&self) -> Result<DynamicImage, MiniViewError> {
+    fn open(&self) -> MVResult<DynamicImage> {
         match &self {
             Source::ByPath(path) => imagecrate::open(path.as_path())
                 .map_err(|_| MiniViewError::FailedToImport(ImportError::OnPathNotFound)),
@@ -42,40 +50,129 @@ impl Source {
     }
 }
 
-pub fn show(config: &Config) -> Result<(), MiniViewError> {
-    let source = config.source();
-    let img = source.open()?;
+#[derive(Debug, Clone, Copy)]
+enum Action {
+    Close,
+}
 
-    let width = img.width();
-    let height = img.height();
-    let img = img.to_rgba();
+struct ImageWindow {
+    window: PistonWindow,
+}
 
-    let mut window: PistonWindow = WindowSettings::new(crate_name!(), [width, height])
-        .fullscreen(config.fullscreen())
-        .exit_on_esc(true)
-        .resizable_when(|| {
-            // if window resizing is not enabled, when setting fullscreen to true, the window won't go
-            // into fullscreen mode
-            config.fullscreen() || config.resizable_window()
-        })
-        .build()
-        .map_err(|_| MiniViewError::UnableToCreateWindow)?;
+impl ImageWindow {
+    pub fn try_new(config: &Config, size: [u32; 2]) -> MVResult<ImageWindow> {
+        let mut window: PistonWindow = WindowSettings::new(crate_name!(), size)
+            .fullscreen(config.fullscreen())
+            .exit_on_esc(true)
+            .resizable_when(|| {
+                // if window resizing is not enabled, when setting fullscreen to true, the window won't go
+                // into fullscreen mode
+                config.fullscreen() || config.resizable_window()
+            })
+            .build()
+            .map_err(|_| MiniViewError::UnableToCreateWindow)?;
 
-    let tex = Texture::from_image(&mut window.factory, &img, &TextureSettings::new())
-        .map_err(|_| MiniViewError::UnableToMapImage)?;
+        window.set_lazy(config.lazy_window());
 
-    window.set_lazy(config.lazy_window());
-    while let Some(event) = window.next() {
-        if let Some(should_exit) = config.exit_when() {
-            if should_exit() {
-                window.set_should_close(true);
-            }
-        }
+        Ok(Self { window })
+    }
 
-        window.draw_2d(&event, |c, g| {
-            image(&tex, c.transform, g);
+    fn next(&mut self) -> Option<Event> {
+        self.window.next()
+    }
+
+    fn draw_image<E: GenericEvent>(&mut self, event: &E, texture: &G2dTexture) {
+        self.window.draw_2d(event, |c, g| {
+            image(texture, c.transform, g);
         });
     }
 
-    Ok(())
+    fn close_window(&mut self) {
+        self.window.set_should_close(true);
+    }
+
+    fn device_factory(&self) -> GfxFactory {
+        self.window.factory.clone()
+    }
+}
+
+impl Debug for ImageWindow {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ImageWindow").finish()
+    }
+}
+
+pub struct MiniView {
+    sender: mpsc::Sender<Action>,
+    handle: thread::JoinHandle<Result<(), MiniViewError>>,
+}
+
+impl MiniView {
+    pub fn show(config: Config) -> MVResult<Self> {
+        let (sender, receiver) = mpsc::channel();
+
+        let source = config.source();
+        let img = source.open()?;
+
+        let width = img.width();
+        let height = img.height();
+        let img = img.to_rgba();
+
+        let handle = thread::spawn(move || {
+            let mut window = ImageWindow::try_new(&config, [width, height])?;
+
+            let texture =
+                Texture::from_image(&mut window.device_factory(), &img, &TextureSettings::new())
+                    .map_err(|_| MiniViewError::UnableToMapImage)?;
+
+            loop {
+                if let Ok(action) = receiver.try_recv() {
+                    return match action {
+                        Action::Close => {
+                            window.close_window();
+                            Ok(())
+                        }
+                    };
+                }
+
+                if let Some(event) = window.next() {
+                    match event {
+                        Event::Input(Input::Close(_)) => {
+                            window.close_window();
+                            return Ok(());
+                        }
+                        Event::Input(Input::Button(ButtonArgs { button, .. }))
+                            if button == Button::Keyboard(Key::Escape) =>
+                        {
+                            window.close_window();
+                            return Ok(());
+                        }
+                        Event::Loop(Loop::AfterRender(_)) => continue,
+                        _ => {}
+                    }
+                    window.draw_image(&event, &texture);
+                }
+            }
+        });
+
+        Ok(Self { sender, handle })
+    }
+
+    pub fn close(self) -> MVResult<()> {
+        self.sender
+            .send(Action::Close)
+            .map_err(|_err| MiniViewError::SendStopError)?;
+
+        self.handle
+            .join()
+            .map_err(|_err| MiniViewError::ViewThreadFailedToJoin)
+            .and_then(|inner| inner)
+    }
+
+    pub fn wait_for_exit(self) -> MVResult<()> {
+        self.handle
+            .join()
+            .map_err(|_err| MiniViewError::ViewThreadFailedToJoin)
+            .and_then(|inner| inner)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,16 +116,16 @@ fn main() -> anyhow::Result<()> {
 
     let config = ConfigBuilder::new(source)
         .set_fullscreen(matches.is_present(OPTION_FULLSCREEN))
-        .allow_resizable_window(matches.is_present(OPTION_WINDOW_RESIZE))
-        .build();
-
-    let controls = MiniView::show(config)?;
+        .allow_resizable_window(matches.is_present(OPTION_WINDOW_RESIZE));
 
     if let Some(close_after) = matches.value_of(OPTION_CLOSE_AFTER) {
         let time = close_after.parse::<u64>()?;
+        let controls = MiniView::show(config.build())?;
         std::thread::sleep(Duration::from_millis(time));
         controls.close()?;
     } else {
+        let config = config.set_lazy_window(true).build();
+        let controls = MiniView::show(config)?;
         controls.wait_for_exit()?;
     }
 

--- a/tests/as_library.rs
+++ b/tests/as_library.rs
@@ -1,23 +1,18 @@
 use common::input;
 use miniview::config::ConfigBuilder;
+use miniview::MiniView;
 use std::time::Duration;
 
 mod common;
 
 #[test]
-fn exit_after_1_second() {
-    let start = std::time::Instant::now();
-
-    let f = Box::new(move || {
-        let time_passed = std::time::Instant::now().duration_since(start);
-        time_passed >= Duration::new(1, 0)
-    });
-
+fn exit_after_100ms() {
     let config = ConfigBuilder::from_path(input())
         .set_fullscreen(true)
         .set_lazy_window(false)
-        .close_window_when(Some(f))
         .build();
 
-    miniview::show(&config).unwrap()
+    let controls = MiniView::show(config).expect("unable to create miniview");
+    std::thread::sleep(Duration::from_millis(100));
+    assert!(controls.close().is_ok());
 }

--- a/tests/as_library.rs
+++ b/tests/as_library.rs
@@ -1,0 +1,23 @@
+use common::input;
+use miniview::config::ConfigBuilder;
+use std::time::Duration;
+
+mod common;
+
+#[test]
+fn exit_after_1_second() {
+    let start = std::time::Instant::now();
+
+    let f = Box::new(move || {
+        let time_passed = std::time::Instant::now().duration_since(start);
+        time_passed >= Duration::new(1, 0)
+    });
+
+    let config = ConfigBuilder::from_path(input())
+        .set_fullscreen(true)
+        .set_lazy_window(false)
+        .close_window_when(Some(f))
+        .build();
+
+    miniview::show(&config).unwrap()
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,47 @@
+use assert_cmd::Command;
+use common::input;
+use parameterized::{ide, parameterized};
+
+mod common;
+
+mod from_path {
+    use super::*;
+    ide!();
+
+    #[parameterized(args = {
+        &[input(), "--close-after", "10"],
+        &["--from-path", input(), "--close-after", "10"],
+    })]
+    fn from_path(args: &[&str]) {
+        let _ = Command::cargo_bin("miniview")
+            .expect("MiniView binary not found")
+            .args(args)
+            .assert()
+            .success();
+    }
+}
+
+mod from_stdin {
+    use super::*;
+
+    #[test]
+    fn stdin_path() {
+        let _ = Command::cargo_bin("miniview")
+            .expect("MiniView binary not found")
+            .args(&["--from-stdin-path", "--close-after", "1"])
+            .write_stdin(input())
+            .assert()
+            .success();
+    }
+
+    #[test]
+    fn stdin_bytes() {
+        let _ = Command::cargo_bin("miniview")
+            .expect("MiniView binary not found")
+            .args(&["--from-stdin-bytes", "--close-after", "10"])
+            .pipe_stdin(input())
+            .expect("Test input file not found")
+            .assert()
+            .success();
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,3 @@
+pub const fn input() -> &'static str {
+    concat!(env!("CARGO_MANIFEST_DIR"), "/resources/plant.jpg")
+}


### PR DESCRIPTION
- Enables library usage by providing miniview::show(Config)
- Provides ConfigBuilder to (hopefully) easily modify the window configuration while providing decent defaults
- As library: opens window in a separate thread which accepts a close event message, useful to let the main thread do some other work instead of being blocking
- As binary: uses function to close window to provide --close-after <n> which, if this option is provided will close the window after approximately 'n' milliseconds
- Added a few tests to test expected usage

closes #6